### PR TITLE
Add PHPStan workflow

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,28 @@
+name: PHPStan
+
+on:
+  workflow_call:
+
+jobs:
+  lint:
+    name: PHPStan
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: 'latest'
+        ini-values: 'memory_limit=1G'
+        coverage: none
+
+    - name: Install Composer dependencies
+      uses: "ramsey/composer-install@v3"
+      with:
+        # Bust the cache at least once a month - output format: YYYY-MM.
+        custom-cache-suffix: $(date -u "+%Y-%m")
+
+    - name: Run PHPStan
+      run: vendor/bin/phpstan analyze


### PR DESCRIPTION
# Description

Add PHPStan workflow to be shared with other repositories

## Type of change

- [x] Chore

## Detailed scenario

### What was tested

Tested called workflow in another repository

### How to test

n/a

## Technical description

### Documentation

Shared workflow is callable by `workflow_call`, and is used by referencing in jobs `uses: wp-media/workflows/.github/workflows/phpstan.yml@{ref}`

# Mandatory Checklist

## Code validation

- [ ] I validated all the Acceptance Criteria. If possible, provide screenshots or videos.
- [ ] I triggered all changed lines of code at least once without new errors/warnings/notices.
- [ ] I implemented built-in tests to cover the new/changed code.

## Code style

- [ ] I wrote a self-explanatory code about what it does.
- [ ] I protected entry points against unexpected inputs.
- [ ] I did not introduce unnecessary complexity.
- [ ] Output messages (errors, notices, logs) are explicit enough for users to understand the issue and are actionnable.

## Unticked items justification

n/a
